### PR TITLE
Fix success signal emission

### DIFF
--- a/ui/EntryWindow/EntryController/entrycontroller.cpp
+++ b/ui/EntryWindow/EntryController/entrycontroller.cpp
@@ -30,7 +30,10 @@ void EntryController::saveEntry(const QString &category, double amount, int id, 
         entryDatahandler->saveEntry(category, amount, id);
         emit entrySuccessfull(true, entryForm);
     }
-    emit entrySuccessfull(false, entryForm);
+    else
+    {
+        emit entrySuccessfull(false, entryForm);
+    }
 }
 
 void EntryController::editEntry(const QString &category, double amount, int id, EntryForm &entryForm)


### PR DESCRIPTION
## Summary
- correct success check in `EntryController::saveEntry` to avoid sending a failure signal after a successful save

## Testing
- `cmake -B build -S .` *(fails: Could not find a package configuration file provided by "QT" with any of the following names: Qt6Config.cmake qt6-config.cmake Qt5Config.cmake qt5-config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_683fe8cf17cc83288a4f7598125ac93a